### PR TITLE
An external expectation module

### DIFF
--- a/test/expect_list_2.act
+++ b/test/expect_list_2.act
@@ -1,0 +1,22 @@
+pool: %INT% 1
+pool: %LIST% 1
+
+@import harness_expectations as expect_to
+
+%INT%:=%[1..4]%
+%LIST%:=[%INT%]
+
+expect: ~%LIST%.append(%INT%)               ==> expect_to.change(len(~%LIST%), by=1)
+expect: ~%LIST% = ~%LIST% + []              ==> expect_to.change(len(~%LIST%), by=0)
+expect: ~%LIST% = ~%LIST% + [%INT%, %INT%]  ==> expect_to.change(len(~%LIST%), by=2)
+
+expect: ~%LIST% = ~%LIST% + [%INT%, %INT%]  ==> expect_to.not_change(len(~%LIST%), by=0)
+expect: ~%LIST% = ~%LIST% + [%INT%, %INT%]  ==> expect_to.not_change(len(~%LIST%), by=1)
+expect: ~%LIST% = ~%LIST% + [%INT%, %INT%]  ==> expect_to.not_change(len(~%LIST%), by=3)
+
+expect: ~%LIST%[:] = []                     ==> expect_to.change(len(~%LIST%), to_value=0)
+expect: ~%LIST%[:] = [%INT%, %INT%]         ==> expect_to.change(len(~%LIST%), to_value=2)
+
+expect: ~%LIST%[:] = [%INT%, %INT%]         ==> expect_to.not_change(len(~%LIST%), to_value=1)
+expect: ~%LIST%[:] = [%INT%, %INT%]         ==> expect_to.not_change(len(~%LIST%), to_value=3)
+

--- a/test/harness_expectations.py
+++ b/test/harness_expectations.py
@@ -1,0 +1,30 @@
+# expect_to.change
+def change_before(value, from_value=None, to_value=None, by=None):
+  return value
+
+def change_after(value, from_value=None, to_value=None, by=None):
+  return value
+
+def change_check(before, after, value, from_value=None, to_value=None, by=None):
+  f_present = not (from_value is None)
+  t_present = not (to_value is None)
+  b_present = not (by is None)
+  if f_present and t_present and b_present:
+    return False
+  else:
+    if f_present and before != from_value:   return False
+    if t_present and after != to_value:      return False
+    if b_present and after != before + by:   return False
+
+  return True
+
+
+# expect_to.not_change
+def not_change_before(value, from_value=None, to_value=None, by=None):
+  return value
+
+def not_change_after(value, from_value=None, to_value=None, by=None):
+  return value
+
+def not_change_check(before, after, value, from_value=None, to_value=None, by=None):
+  return not change_check(before, after, value, from_value=from_value, to_value=to_value, by=by)


### PR DESCRIPTION
  for sharing and abstracting common epectations (e.g., change
  in numerical velues)

You can assert how much a value changes (..., by=2), from which value
  (..., from_value=0), and to which value (..., to_value=2). You can
  use these attributes together (e.g., (from_value=1, to_value=4, by=3)).

There is also a counterpart: not_change(from_value, to_value, by).

Example .act file:

    pool: %INT% 1
    pool: %LIST% 1

    @import harness_expectations as expect_to

    %INT%:=%[1..4]%
    %LIST%:=[%INT%]

    expect: ~%LIST%.append(%INT%)               ==> expect_to.change(len(~%LIST%), by=1)
    expect: ~%LIST% = ~%LIST% + []              ==> expect_to.change(len(~%LIST%), by=0)
    expect: ~%LIST% = ~%LIST% + [%INT%, %INT%]  ==> expect_to.change(len(~%LIST%), by=2)

    expect: ~%LIST% = ~%LIST% + [%INT%, %INT%]  ==> expect_to.not_change(len(~%LIST%), by=0)
    expect: ~%LIST% = ~%LIST% + [%INT%, %INT%]  ==> expect_to.not_change(len(~%LIST%), by=1)
    expect: ~%LIST% = ~%LIST% + [%INT%, %INT%]  ==> expect_to.not_change(len(~%LIST%), by=3)

    expect: ~%LIST%[:] = []                     ==> expect_to.change(len(~%LIST%), to_value=0)
    expect: ~%LIST%[:] = [%INT%, %INT%]         ==> expect_to.change(len(~%LIST%), to_value=2)

    expect: ~%LIST%[:] = [%INT%, %INT%]         ==> expect_to.not_change(len(~%LIST%), to_value=1)
    expect: ~%LIST%[:] = [%INT%, %INT%]         ==> expect_to.not_change(len(~%LIST%), to_value=3)