### PR TITLE
Back-reference pool variables

### DIFF
--- a/src/harnessmaker.py
+++ b/src/harnessmaker.py
@@ -215,6 +215,27 @@ def expandRange(original):
             else:
                 newVersion.append(c)
         current = newVersion
+
+    for index, line in enumerate(newVersion):
+        for refPool in re.findall("%([^%,]*)\s*,\s*(\d+)%", line):
+            # it finds e.g., ('LIST', '2') if you have   ~%LIST,2%   in your .act file
+            poolName, refIndex = refPool
+            
+            # if you had 
+            # ~%LIST% = ~%LIST% + [%INT%, %INT%]
+            # in your .act file, and in this particular line they were expanded to e.g., 
+            # ~%LIST% [2] = ~%LIST% [3] + [%INT% [0], %INT% [0]]
+            # then poolOccurences will be ['2', '3']
+            poolOccurences = re.findall("%"+poolName+"%\s*\[(\d+)\]", line)
+
+            # refIndex is 2, so the actual pool used for the secons %LIST% is poolOccurences[1]
+            actualPoolUsed = poolOccurences[int(refIndex)-1]
+            
+            # replace   ~%LIST,2%    with    self.p_LIST[3]
+            line = re.sub(r"~?%([^%,]*)\s*,\s*(\d+)%", poolPrefix+"\\1["+actualPoolUsed+"]", line)
+            
+            newVersion[index] = line
+
     return newVersion
 
 code = expandRange(code)

--- a/test/expect_list.act
+++ b/test/expect_list.act
@@ -1,5 +1,5 @@
 pool: %INT% 1
-pool: %LIST% 1
+pool: %LIST% 2
 
 <@
 def change_len_before(list, amount):
@@ -16,6 +16,16 @@ def change_len_check(before, after, list, amount):
 %INT%:=%[1..4]%
 %LIST%:=[%INT%]
 
-expect: ~%LIST%.append(%INT%)               ==> change_len(~%LIST%, 1)
-expect: ~%LIST% = ~%LIST% + []              ==> change_len(~%LIST%, 0)
-expect: ~%LIST% = ~%LIST% + [%INT%, %INT%]  ==> change_len(~%LIST%, 2)
+%LIST% = %LIST% + %LIST%
+%LIST% = [%INT%]
+%LIST% = [%INT%, %INT%]
+
+
+expect: ~%LIST%.append(%INT%)                 ==> change_len(%LIST,1%, 1)
+
+expect: ~%LIST% = %LIST,1% + []               ==> change_len(%LIST,1%, 0)
+
+expect: ~%LIST% = %LIST,1% + [%INT%, %INT%]   ==> change_len(%LIST,1%, 2)
+
+# size of the list after in-place duplication has increased by half of its current size (i.e., it was 6 and now is 12, so it had increased by 12/2=6)
+expect: ~%LIST% = %LIST,1% + %LIST,1%         ==> change_len(%LIST,1%, len(%LIST,1%)/2) 


### PR DESCRIPTION
Now, `~%LIST% = ~%LIST,1% + []` expands only the first %LIST%; the
second list will use the same index as the first variable:

  self.p_LIST[0] = self.p_LIST[0] + []

And

  some_fun(%X%, %X%, %X%) ==> check(%X,3%)

will use the same index as the third %X% for the check function.

  expect: ~%LIST% = %LIST,1% + %LIST,1% ==> change_len(%LIST,1%, len(%LIST,1%)/2)

Would mean the size of the list after in-place duplication has increased
by half of its current size (i.e., it was 6 and now is 12, so it had
increased by 12/2=6)